### PR TITLE
Refresh timestamps on visibility

### DIFF
--- a/render.js
+++ b/render.js
@@ -11,12 +11,53 @@ const editsCache = new Map()
 const EDIT_CACHE_TTL_MS = 5000
 
 const editState = new Map()
+const timestampRefreshMs = 60000
+const visibleTimestamps = new Map()
+let timestampObserver = null
 
 const getEditState = (hash) => {
   if (!editState.has(hash)) {
     editState.set(hash, { currentIndex: null, userNavigated: false })
   }
   return editState.get(hash)
+}
+
+const refreshTimestamp = async (element, timestamp) => {
+  if (!document.body.contains(element)) {
+    const stored = visibleTimestamps.get(element)
+    if (stored) { clearInterval(stored.intervalId) }
+    visibleTimestamps.delete(element)
+    return
+  }
+  element.textContent = await apds.human(timestamp)
+}
+
+const observeTimestamp = (element, timestamp) => {
+  if (!element) { return }
+  element.dataset.timestamp = timestamp
+  if (!timestampObserver) {
+    timestampObserver = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        const target = entry.target
+        const ts = target.dataset.timestamp
+        if (!ts) { return }
+        if (entry.isIntersecting) {
+          refreshTimestamp(target, ts)
+          if (!visibleTimestamps.has(target)) {
+            const intervalId = setInterval(() => {
+              refreshTimestamp(target, ts)
+            }, timestampRefreshMs)
+            visibleTimestamps.set(target, { intervalId })
+          }
+        } else {
+          const stored = visibleTimestamps.get(target)
+          if (stored) { clearInterval(stored.intervalId) }
+          visibleTimestamps.delete(target)
+        }
+      })
+    })
+  }
+  timestampObserver.observe(element)
 }
 
 const renderBody = async (body, replyHash) => {
@@ -363,7 +404,7 @@ render.meta = async (blob, opened, hash, div) => {
       syncPrevious(yaml)
 
       const ts = h('a', {href: '#' + hash}, [humanTime])
-      setInterval(async () => {ts.textContent = await apds.human(timestamp)}, 1000)
+      observeTimestamp(ts, timestamp)
 
       const qrTarget = h('div', {id: 'qr-target' + hash, classList: 'qr-target', style: 'margin: 8px auto 0 auto; text-align: center; max-width: 400px;'})
       const { raw, rawDiv } = buildRawControls(blob, opened, contentBlob)
@@ -399,7 +440,7 @@ render.meta = async (blob, opened, hash, div) => {
   }
 
   const ts = h('a', {href: '#' + hash}, [humanTime])
-  setInterval(async () => {ts.textContent = await apds.human(timestamp)}, 1000)
+  observeTimestamp(ts, timestamp)
 
   const pubkey = await apds.pubkey()
   const canEdit = pubkey && pubkey === author


### PR DESCRIPTION
### Motivation
- Reduce per-message `setInterval` timers to avoid many background updates and potential resource/battery drain.
- Only update human-readable timestamps when they are visible to the user to improve performance.
- Provide a slower periodic refresh while timestamps remain visible so times stay reasonably accurate.
- Ensure intervals are cleared when timestamp elements are removed to prevent leaks.

### Description
- Added a shared `IntersectionObserver` (`timestampObserver`) and a `visibleTimestamps` map to track visible timestamp elements.
- Implemented `observeTimestamp` to attach timestamps to the observer and `refreshTimestamp` to update text via `apds.human` and to clear intervals when elements are removed.
- Replaced per-message `setInterval` calls in `render.meta` with calls to `observeTimestamp`, using a `timestampRefreshMs` default of `60000` (one minute) for visible polling.
- Ensure intervals are cleared when elements go out of view or are removed from the DOM.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695af8c5570c832ebe61d1b51d39aede)